### PR TITLE
Changing naming to flow better in command

### DIFF
--- a/src/REstomp/StompFrame.cs
+++ b/src/REstomp/StompFrame.cs
@@ -47,7 +47,7 @@ namespace REstomp
         public StompFrame With<TMember>(Expression<Func<StompFrame, TMember>> mutationSelectorExpression, TMember value)
         {
             var memberName = ((MemberExpression)mutationSelectorExpression.Body).Member.Name;
-            var commandString = Command;
+            var command = Command;
             var headers = Headers;
             var body = Body;
 
@@ -56,7 +56,7 @@ namespace REstomp
             switch (memberName)
             {
                 case nameof(Command):
-                    commandString = (string)obj;
+                    command = (string)obj;
                     break;
                 case nameof(Headers):
                     headers = (ImmutableDictionary<string, string>)obj;
@@ -66,7 +66,7 @@ namespace REstomp
                     break;
             }
 
-            return new StompFrame(commandString, headers, body);
+            return new StompFrame(command, headers, body);
         }
 
     }

--- a/src/REstomp/StompParser.cs
+++ b/src/REstomp/StompParser.cs
@@ -9,7 +9,7 @@ namespace REstomp
 {
     public static class StompParser
     {
-        public static class Commands
+        public static class Command
         {
             private static readonly string[] SupportedCommands =
             {
@@ -63,7 +63,7 @@ namespace REstomp
         /// <typeparam name="TStream">The type of the stream.</typeparam>
         /// <param name="stream">The stream to read from.</param>
         /// <param name="stompFrame">An existing stomp frame to use as a base.</param>
-        /// <returns>CommandString if read; otherwise null</returns>
+        /// <returns>A tuple of the Stream and the resultant StompFrame</returns>
         public static async Task<Tuple<TStream, StompFrame>> ReadStompCommand<TStream>(
             TStream stream, StompFrame stompFrame) where TStream : Stream
         {
@@ -76,7 +76,7 @@ namespace REstomp
         /// </summary>
         /// <typeparam name="TStream">The type of the stream.</typeparam>
         /// <param name="stream">The stream to read from.</param>
-        /// <returns>CommandString if read; otherwise null</returns>
+        /// <returns>A tuple of the Stream and the resultant StompFrame</returns>
         public static async Task<Tuple<TStream, StompFrame>> ReadStompCommand<TStream>(
             TStream stream) where TStream : Stream
         {
@@ -90,7 +90,7 @@ namespace REstomp
         /// <typeparam name="TStream">The type of the stream.</typeparam>
         /// <param name="stream">The stream to read from.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>CommandString if read; otherwise null</returns>
+        /// <returns>A tuple of the Stream and the resultant StompFrame</returns>
         public static async Task<Tuple<TStream, StompFrame>> ReadStompCommand<TStream>(
             TStream stream, CancellationToken cancellationToken) where TStream : Stream
         {
@@ -105,7 +105,7 @@ namespace REstomp
         /// <param name="stream">The stream to read from.</param>
         /// <param name="stompFrame">An existing stomp frame to use as a base.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>CommandString if read; otherwise null</returns>
+        /// <returns>A tuple of the Stream and the resultant StompFrame</returns>
         /// <exception cref="CommandParseException"></exception>
         public static async Task<Tuple<TStream, StompFrame>> ReadStompCommand<TStream>(
             TStream stream, StompFrame stompFrame, CancellationToken cancellationToken)
@@ -176,10 +176,10 @@ namespace REstomp
                 }
 
                 //Convert bytes to string in UTF-8 from beginning to start of EOL
-                var parsedCommandString = Encoding.UTF8.GetString(commandBuffer, 0, eolIndex);
+                var parsedCommand = Encoding.UTF8.GetString(commandBuffer, 0, eolIndex);
 
-                if (Commands.IsSupported(parsedCommandString))
-                    command = parsedCommandString;
+                if (Command.IsSupported(parsedCommand))
+                    command = parsedCommand;
             }
 
             if (command == null) throw new CommandParseException();

--- a/src/REstomp/StompService.cs
+++ b/src/REstomp/StompService.cs
@@ -25,7 +25,7 @@ namespace REstomp
         public void Start()
         {
             StompFrame.Empty
-                .With(frame => frame.Command, StompParser.Commands.CONNECTED);
+                .With(frame => frame.Command, StompParser.Command.CONNECTED);
 
             Listener.Start(100);
 
@@ -116,7 +116,7 @@ namespace REstomp
 
                     var bodyBuilder = new List<byte>();
 
-                    if (StompParser.Commands.CanHaveBody(streamAndFrame.Item2.Command))
+                    if (StompParser.Command.CanHaveBody(streamAndFrame.Item2.Command))
                     {
                         var contentLength = -1;
                         var bodyBytesRead = 0;

--- a/test/REstomp.Test/Tests.cs
+++ b/test/REstomp.Test/Tests.cs
@@ -95,10 +95,10 @@ namespace REstomp.Test
         [Fact(DisplayName = "StompFrame With Command")]
         public void StompFrameWithCommand()
         {
-            var expectation = new StompFrame(StompParser.Commands.CONNECT);
+            var expectation = new StompFrame(StompParser.Command.CONNECT);
 
             var newFrame = StompFrame.Empty
-                .With(frame => frame.Command, StompParser.Commands.CONNECT);
+                .With(frame => frame.Command, StompParser.Command.CONNECT);
 
             Assert.NotNull(newFrame);
             Assert.Equal(expectation.Command, newFrame.Command);


### PR DESCRIPTION
- Renaming StompParser.Commands to .Command
- replacing remaining occurences of commandString