### PR TITLE
Body Parsing

### DIFF
--- a/src/REstomp/ContentLengthException.cs
+++ b/src/REstomp/ContentLengthException.cs
@@ -1,0 +1,9 @@
+namespace REstomp
+{
+    public class ContentLengthException : System.Exception
+    {
+        public ContentLengthException() { }
+        public ContentLengthException( string message ) : base( message ) { }
+        public ContentLengthException( string message, System.Exception inner ) : base( message, inner ) { }
+    }
+}

--- a/src/REstomp/StompParser.cs
+++ b/src/REstomp/StompParser.cs
@@ -469,7 +469,7 @@ namespace REstomp
                         throw;
                     }
 
-                    bytesFound += await stream.ReadAsync(bodyLengthBuffer, bytesFound, bodyLengthBuffer.Length, cancellationToken);
+                    bytesFound += await stream.ReadAsync(bodyLengthBuffer, bytesFound, bodyLengthBuffer.Length - bytesFound, cancellationToken);
 
                     for (var i = parserIndex; i < bytesFound; i++)
                     {

--- a/src/REstomp/StompParser.cs
+++ b/src/REstomp/StompParser.cs
@@ -281,7 +281,6 @@ namespace REstomp
 
             while (true)
             {
-                //check the status of the cancellation token
                 //Check for cancellation and attempt to handle it gracefully.
                 try
                 {
@@ -370,7 +369,7 @@ namespace REstomp
                 Buffer.BlockCopy(headerBuffer, parserIndex, relevantBytes, 0,
                     bytesFound - parserIndex);
 
-                //get ALLLLLLLL of the bytes we've read and put them in an array
+                //get ALLLLLLLL of the bytes we've found and put them in an array
                 var readBytes = headerContents
                         .SelectMany(list => list)
                         .Union(headerLine)
@@ -397,5 +396,139 @@ namespace REstomp
 
             return Tuple.Create(stream, frameWithHeaders, bodyBuffer);
         }
+
+        //TODO: add overloads
+
+        /// <summary>
+        /// Reads a STOMP body block asynchronyously.
+        /// </summary>
+        /// <typeparam name="TStream">The type of the stream.</typeparam>
+        /// <param name="stream">The stream to read from.</param>
+        /// <param name="stompFrame">An existing stomp frame to use as a base.</param>
+        /// <param name="remainderBytes">The remainder bytes from header parsing.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A tuple of the Stream and the resultant StompFrame.</returns>
+        /// <exception cref="HeaderParseException"></exception>
+        public static async Task<Tuple<TStream, StompFrame>> ReadStompBody<TStream>(
+            TStream stream, StompFrame stompFrame, byte[] remainderBytes, CancellationToken cancellationToken)
+            where TStream : Stream
+        {
+            var originalStreamPosition = stream.Position;
+
+            //list of bytes that we read
+            var bodyList = new List<byte>();
+
+            //if we have a content-length header, we MUST read the number of bytes that the value specifies
+            var contentLength = -1;
+            var bodyBytesRead = 0;
+
+            //Attempt to find and use the content-length header.
+            string contentLengthHeaderValue;
+            if (stompFrame.Headers.TryGetValue("content-length", out contentLengthHeaderValue))
+                if (!int.TryParse(contentLengthHeaderValue, out contentLength))
+                    throw new ContentLengthException(); //ERROR frame, content-length not assignable to int
+
+            //add the remainder bytes to the body
+            bodyList.AddRange(remainderBytes);
+            bodyBytesRead += remainderBytes.Length;
+
+            //if our remainder was longer than content length, throw an exception
+            if(contentLength != -1 && remainderBytes.Length > contentLength)
+                throw new ContentLengthException();
+
+            //if we have content length, read that many bytes. the following byte must be 0x00
+            if (contentLength != -1)
+            {
+                //grab the remaining body and the following 0x00 null byte
+                var bodyLengthBuffer = new byte[contentLength - bodyBytesRead + 1];
+                var bytesFound = 0;
+                var parserIndex = 0;
+
+                //read from stream and add to bodyList until we've read the remaining body and 0x00 byte
+                while (bodyBytesRead < contentLength + 1)
+                {
+                    //Check for cancellation and attempt to handle it gracefully.
+                    try
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+                    catch (OperationCanceledException opEx)
+                    {
+                        try
+                        {
+                            stream.Position = originalStreamPosition;
+                        }
+                        catch (Exception)
+                        {
+                            // Nothing we can do here. Sad day.
+                        }
+
+                        //add the bytes that we read for a potential failsafe
+                        opEx.Data.Add("ConsumedBytes", bodyList);
+
+                        throw;
+                    }
+
+                    bytesFound += await stream.ReadAsync(bodyLengthBuffer, bytesFound, bodyLengthBuffer.Length, cancellationToken);
+
+                    for (var i = parserIndex; i < bytesFound; i++)
+                    {
+                        bodyList.Add(bodyLengthBuffer[i]);
+                    }
+                    bodyBytesRead = bytesFound + remainderBytes.Length;
+                    parserIndex = bytesFound;
+                }
+
+                //if the last byte wasn't actually 0x00, throw an exception
+                if (bodyList.Last() != 0x00)
+                    throw new ContentLengthException();
+            }
+            else
+            {
+                var bodyBuffer = new byte[20];
+                
+                //if we don't have a content length, just read until we find a 0x00 null byte
+                while (bodyList.Last() != 0x00)
+                {
+                    //Check for cancellation and attempt to handle it gracefully.
+                    try
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+                    catch (OperationCanceledException opEx)
+                    {
+                        try
+                        {
+                            stream.Position = originalStreamPosition;
+                        }
+                        catch (Exception)
+                        {
+                            // Nothing we can do here. Sad day.
+                        }
+
+                        //add the bytes that we read for a potential failsafe
+                        opEx.Data.Add("ConsumedBytes", bodyList);
+
+                        throw;
+                    }
+
+                    var bytesFound = await stream.ReadAsync(bodyBuffer, 0, bodyBuffer.Length, cancellationToken);
+
+                    for (int i = 0; i < bytesFound; i++)
+                    {
+                        if (bodyList.Last() != 0x00) bodyList.Add(bodyBuffer[i]);
+                        else break;
+                    }
+                }
+            }
+
+            //remove the trailing 0x00
+            bodyList.RemoveAt(bodyList.Count - 1);
+
+            var newFrame = stompFrame.With(frame => frame.Body, bodyList.ToImmutableArray());
+
+            return Tuple.Create(stream, newFrame);
+        }
+
     }
 }

--- a/test/REstomp.Test/Tests.cs
+++ b/test/REstomp.Test/Tests.cs
@@ -2,6 +2,8 @@
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Threading;
 using Xunit;
 
 namespace REstomp.Test
@@ -57,7 +59,7 @@ namespace REstomp.Test
                 streamWriter.Write("version:1.2");
                 streamWriter.Write(eol);
                 streamWriter.Write(eol);
-                streamWriter.Write(0x00);
+                streamWriter.Write((char)0x00);
                 streamWriter.Flush();
 
                 memStream.Position = 0;
@@ -83,7 +85,7 @@ namespace REstomp.Test
                     streamWriter.Write("version:1.2");
                     streamWriter.Write(eol);
                     streamWriter.Write(eol);
-                    streamWriter.Write(0x00);
+                    streamWriter.Write((char)0x00);
                     streamWriter.Flush();
 
                     memStream.Position = 0;
@@ -145,7 +147,7 @@ namespace REstomp.Test
                 }
                 streamWriter.Write(eol);
                 streamWriter.Write(eol);
-                streamWriter.Write(0x00);
+                streamWriter.Write((char)0x00);
                 streamWriter.Flush();
 
                 memStream.Position = 0;
@@ -178,7 +180,7 @@ namespace REstomp.Test
                     streamWriter.Write(header);
                     streamWriter.Write(eol);
                     streamWriter.Write(eol);
-                    streamWriter.Write(0x00);
+                    streamWriter.Write((char)0x00);
                     streamWriter.Flush();
 
                     memStream.Position = 0;
@@ -187,6 +189,153 @@ namespace REstomp.Test
                     var parsedHeaders = await StompParser.ReadStompHeaders(parsedCommand.Item1, parsedCommand.Item2);
                 }
             });
+        }
+
+        [Theory(DisplayName = "Content Length Must Have Int Value")]
+        [InlineData("content-length:ten")]
+        [InlineData("content-length:3000000000")]
+        public async void ContentLengthParse(string header)
+        {
+            var command = StompParser.Command.MESSAGE;
+            var eol = "\r\n";
+
+            await Assert.ThrowsAsync<ContentLengthException>(async () =>
+            {
+                using (var memStream = new MemoryStream())
+                using (var streamWriter = new StreamWriter(memStream))
+                {
+                    streamWriter.Write(command);
+                    streamWriter.Write(eol);
+                    streamWriter.Write(header);
+                    streamWriter.Write(eol);
+                    streamWriter.Write(eol);
+                    streamWriter.Write("0123456789");
+                    streamWriter.Write((char)0x00);
+                    streamWriter.Flush();
+
+                    memStream.Position = 0;
+
+                    var parsedCommand = await StompParser.ReadStompCommand(memStream);
+                    var parsedHeaders = await StompParser.ReadStompHeaders(parsedCommand.Item1, parsedCommand.Item2);
+                    var parsedBody = await StompParser
+                        .ReadStompBody(parsedHeaders.Item1, parsedHeaders.Item2, parsedHeaders.Item3, CancellationToken.None);
+                }
+            });
+        }
+
+        [Fact(DisplayName = "Content Cannot Be Longer Than Content Length Value")]
+        public async void ContentTooLong()
+        {
+            var command = StompParser.Command.MESSAGE;
+            var eol = "\n";
+            var header = "content-length:5";
+
+            await Assert.ThrowsAsync<ContentLengthException>(async () =>
+            {
+                using (var memStream = new MemoryStream())
+                using (var streamWriter = new StreamWriter(memStream))
+                {
+                    streamWriter.Write(command);
+                    streamWriter.Write(eol);
+                    streamWriter.Write(header);
+                    streamWriter.Write(eol);
+                    streamWriter.Write(eol);
+                    streamWriter.Write("0123456789");
+                    streamWriter.Write((char)0x00);
+                    streamWriter.Flush();
+
+                    memStream.Position = 0;
+
+                    var parsedCommand = await StompParser.ReadStompCommand(memStream);
+                    var parsedHeaders = await StompParser.ReadStompHeaders(parsedCommand.Item1, parsedCommand.Item2);
+                    var parsedBody = await StompParser
+                        .ReadStompBody(parsedHeaders.Item1, parsedHeaders.Item2, parsedHeaders.Item3, CancellationToken.None);
+                }
+            });
+        }
+
+        [Fact(DisplayName = "Content Length Matches Content Length Value")]
+        public async void ContentLengthMatchesValue()
+        {
+            var bodyString = "0123456789abcdefghijk1234567890abcd";
+            var command = StompParser.Command.MESSAGE;
+            var headers = new Dictionary<string, string>
+                { { "content-length", bodyString.Length.ToString() } };
+            var body = Encoding.UTF8.GetBytes(bodyString);
+
+            var expectation = new StompFrame(command, headers, body);
+
+            using (var memStream = new MemoryStream())
+            using (var streamWriter = new StreamWriter(memStream))
+            {
+                var eol = "\r\n";
+                streamWriter.Write(command);
+                streamWriter.Write(eol);
+                foreach (var header in headers)
+                {
+                    streamWriter.Write($"{header.Key}:{header.Value}");
+                }
+                streamWriter.Write(eol);
+                streamWriter.Write(eol);
+                streamWriter.Write(bodyString);
+                streamWriter.Write((char)0x00);
+                streamWriter.Flush();
+
+                memStream.Position = 0;
+
+                var parsedCommand = await StompParser.ReadStompCommand(memStream);
+                var parsedHeaders = await StompParser.ReadStompHeaders(parsedCommand.Item1, parsedCommand.Item2);
+                var parsedBody = await StompParser
+                    .ReadStompBody(parsedHeaders.Item1, parsedHeaders.Item2, parsedHeaders.Item3, CancellationToken.None);
+
+                Assert.StrictEqual(expectation.Command, parsedCommand.Item2.Command);
+                Assert.Equal(expectation.Headers, parsedHeaders.Item2.Headers);
+                Assert.True(Encoding.UTF8.GetString(expectation.Body.ToArray()) 
+                    == Encoding.UTF8.GetString(parsedBody.Item2.Body.ToArray()));
+                Assert.Equal(parsedBody.Item2.Body.Length, bodyString.Length);
+            }
+        }
+
+        [Fact(DisplayName = "Null Byte Signals End of Non-Content Length Frame")]
+        public async void ContentEndsOnNull()
+        {
+            var bodyString = "0123456789abcdefghijk1234567890abcd";
+            var command = StompParser.Command.MESSAGE;
+            var headers = new Dictionary<string, string>
+                { { "key", "value" } };
+            var body = Encoding.UTF8.GetBytes(bodyString);
+
+            var expectation = new StompFrame(command, headers, body);
+
+            using (var memStream = new MemoryStream())
+            using (var streamWriter = new StreamWriter(memStream))
+            {
+                var eol = "\r\n";
+                streamWriter.Write(command);
+                streamWriter.Write(eol);
+                foreach (var header in headers)
+                {
+                    streamWriter.Write($"{header.Key}:{header.Value}");
+                }
+                streamWriter.Write(eol);
+                streamWriter.Write(eol);
+                streamWriter.Write(bodyString);
+                streamWriter.Write((char)0x00);
+                streamWriter.Flush();
+
+                memStream.Position = 0;
+
+                var parsedCommand = await StompParser.ReadStompCommand(memStream);
+                var parsedHeaders = await StompParser.ReadStompHeaders(parsedCommand.Item1, parsedCommand.Item2);
+                var parsedBody = await StompParser
+                    .ReadStompBody(parsedHeaders.Item1, parsedHeaders.Item2, parsedHeaders.Item3, CancellationToken.None);
+
+                Assert.StrictEqual(expectation.Command, parsedCommand.Item2.Command);
+                Assert.Equal(expectation.Headers, parsedHeaders.Item2.Headers);
+                Assert.True(Encoding.UTF8.GetString(expectation.Body.ToArray())
+                    == Encoding.UTF8.GetString(parsedBody.Item2.Body.ToArray()));
+                Assert.Equal(parsedBody.Item2.Body.Length, bodyString.Length);
+            }
         }
     }
 }


### PR DESCRIPTION
- Adding method to parse the body given a stream, frame, remainder byte array, and cancellation token.
- Adding ContentLengthException.
- Preventing vulnerability when reading from string in body parse.
- Adding unit test to guarantee ContentLengthExceptions are thrown when a length cannot be parsed.
- Adding unit test to guarantee ContentLengthExceptions are thrown when the content length is longer than stated.
- Adding unit test to check that bodies with no specified length end on null byte.
- Adding unit test to confirm that valid bodies with a specified content length are handled as such.