### PR TITLE
Changing stomp frames to have an immutable array of header values

### DIFF
--- a/src/REstomp/StompFrame.cs
+++ b/src/REstomp/StompFrame.cs
@@ -7,29 +7,50 @@ namespace REstomp
 {
     public class StompFrame
     {
-        public StompFrame(string command, IDictionary<string, string> headers, byte[] body)
+        public StompFrame(string command, KeyValuePair<string, string>[] headers, byte[] body)
         {
             Command = command;
-            Headers = headers?.ToImmutableDictionary() ?? ImmutableDictionary<string, string>.Empty;
+            Headers = headers?.ToImmutableArray() ?? ImmutableArray<KeyValuePair<string, string>>.Empty;
 
             if(body != null)
                 Body = body.ToImmutableArray();
         }
 
-        public StompFrame(string command, IDictionary<string, string> headers, ImmutableArray<byte> body)
+        public StompFrame(string command, ImmutableArray<KeyValuePair<string, string>> headers, byte[] body)
         {
             Command = command;
-            Headers = headers?.ToImmutableDictionary() ?? ImmutableDictionary<string, string>.Empty;
+            Headers = headers;
+
+            if (body != null)
+                Body = body.ToImmutableArray();
+        }
+
+        public StompFrame(string command, KeyValuePair<string, string>[] headers, ImmutableArray<byte> body)
+        {
+            Command = command;
+            Headers = headers?.ToImmutableArray() ?? ImmutableArray<KeyValuePair<string, string>>.Empty;
             Body = body;
         }
 
-        public StompFrame(string command, IDictionary<string, string> headers)
+        public StompFrame(string command, ImmutableArray<KeyValuePair<string, string>> headers, ImmutableArray<byte> body)
+        {
+            Command = command;
+            Headers = headers;
+            Body = body;
+        }
+
+        public StompFrame(string command, KeyValuePair<string, string>[] headers)
+            : this(command, headers, null)
+        {
+        }
+
+        public StompFrame(string command, ImmutableArray<KeyValuePair<string, string>> headers)
             : this(command, headers, null)
         {
         }
 
         public StompFrame(string command)
-            : this(command, ImmutableDictionary<string, string>.Empty, null)
+            : this(command, ImmutableArray<KeyValuePair<string, string>>.Empty, null)
         {
         }
 
@@ -39,7 +60,7 @@ namespace REstomp
 
         public string Command { get; }
 
-        public ImmutableDictionary<string, string> Headers { get; }
+        public ImmutableArray<KeyValuePair<string, string>> Headers { get; }
 
         public ImmutableArray<byte> Body { get; }
 
@@ -61,7 +82,7 @@ namespace REstomp
                     command = (string)obj;
                     break;
                 case nameof(Headers):
-                    headers = (ImmutableDictionary<string, string>)obj;
+                    headers = (ImmutableArray<KeyValuePair <string, string>>)obj;
                     break;
                 case nameof(Body):
                     body = (ImmutableArray<byte>)obj;
@@ -69,6 +90,13 @@ namespace REstomp
             }
 
             return new StompFrame(command, headers, body);
+        }
+
+        public StompFrame With(
+            Expression<Func<StompFrame, ImmutableArray<KeyValuePair<string, string>>>> mutationSelectorExpression,
+            KeyValuePair<string, string>[] value)
+        {
+            return this.With(mutationSelectorExpression, value.ToImmutableArray());
         }
 
     }

--- a/src/REstomp/StompHeaderExtensions.cs
+++ b/src/REstomp/StompHeaderExtensions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace REstomp
+{
+    public static class StompHeaderExtensions
+    {
+
+        public static ImmutableArray<string> UniqueKeys(this ImmutableArray<KeyValuePair<string, string>> headerPairs)
+        {
+            List<string> keys = new List<string>();
+
+            foreach (var keyValuePair in headerPairs)
+            {
+                if(!keys.Contains(keyValuePair.Key))
+                    keys.Add(keyValuePair.Key);
+            }
+
+            return keys.ToImmutableArray();
+        }
+
+        public static string GetValueOrNull(this ImmutableArray<KeyValuePair<string, string>> headerPairs, string key)
+        {
+            foreach (var keyValuePair in headerPairs)
+            {
+                if (key == keyValuePair.Key)
+                {
+                    return keyValuePair.Value;
+                }
+            }
+
+            return null;
+        }
+
+        public static bool TryGetValue(this ImmutableArray<KeyValuePair<string, string>> headerPairs, string key, out string value)
+        {
+            foreach (var keyValuePair in headerPairs)
+            {
+                if (key == keyValuePair.Key)
+                {
+                    value = keyValuePair.Value;
+                    return true;
+                }
+            }
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/src/REstomp/StompParser.cs
+++ b/src/REstomp/StompParser.cs
@@ -249,7 +249,7 @@ namespace REstomp
             where TStream : Stream
         {
             //put our headers with values into a dictionary after parsing them
-            var headers = new Dictionary<string, string>();
+            var headers = new List<KeyValuePair<string,string>>();
 
             var headerBuffer = new byte[20];
             var bytesFound = 0;
@@ -356,15 +356,17 @@ namespace REstomp
                 throw new HeaderParseException();
             }
 
-            //Add header if key not already added (first come, first-only served)
-            foreach (var segments in headerSegments
-                .Where(segments => !headers.ContainsKey(segments[0])))
+            //Add headers to the list
+            foreach (var segments in headerSegments)
             {
-                headers.Add(segments[0], segments[1]);
+                var key = segments[0];
+                var value = segments[1];
+                var newPair = new KeyValuePair<string, string>(key, value);
+                headers.Add(newPair);
             }
 
             //create a Stomp Frame with headers
-            var frameWithHeaders = stompFrame.With(frame => frame.Headers, headers.ToImmutableDictionary());
+            var frameWithHeaders = stompFrame.With(frame => frame.Headers, headers.ToImmutableArray());
 
             //find the remaining bytes and put them at the front of an array so we don't lose part of the body
             var bodyBuffer = new byte[bytesFound - parserIndex];

--- a/test/REstomp.Test/Tests.cs
+++ b/test/REstomp.Test/Tests.cs
@@ -325,7 +325,7 @@ namespace REstomp.Test
                 streamWriter.Write(eol);
                 foreach (var headerPair in headerArray)
                 {
-                    streamWriter.Write($"{header.Key}:{header.Value}");
+                    streamWriter.Write($"{headerPair.Key}:{headerPair.Value}");
                 }
                 streamWriter.Write(eol);
                 streamWriter.Write(eol);

--- a/test/REstomp.Test/Tests.cs
+++ b/test/REstomp.Test/Tests.cs
@@ -106,7 +106,7 @@ namespace REstomp.Test
             Assert.NotNull(newFrame);
             Assert.Equal(expectation.Command, newFrame.Command);
 
-            Assert.Empty(newFrame.Headers);
+            Assert.True(newFrame.Headers.IsDefault);
             Assert.True(newFrame.Body.IsDefault);
         }
 
@@ -114,16 +114,18 @@ namespace REstomp.Test
         [InlineData("content-length", "126")]
         public void StompFrameWithHeaders(string headerKey, string headerValue)
         {
-            var expectation = new StompFrame(StompParser.Command.MESSAGE,
-                new Dictionary<string, string> { { headerKey, headerValue } });
+            var header = new KeyValuePair<string, string>(headerKey, headerValue);
+            var headerArray = new KeyValuePair<string, string>[1];
+            headerArray[0] = header;
+            var expectation = new StompFrame(StompParser.Command.MESSAGE, headerArray);
 
             var newFrame = new StompFrame(StompParser.Command.MESSAGE)
-                .With(frame => frame.Headers, new Dictionary<string, string> { { headerKey, headerValue } }.ToImmutableDictionary());
-
+                .With(frame => frame.Headers, headerArray);
             Assert.NotNull(newFrame);
             Assert.Equal(expectation.Command, newFrame.Command);
 
-            Assert.Equal(expectation.Headers, newFrame.Headers);
+            Assert.Equal(expectation.Headers[0].Key, newFrame.Headers[0].Key);
+            Assert.Equal(expectation.Headers[0].Value, newFrame.Headers[0].Value);
             Assert.True(newFrame.Body.IsDefault);
         }
 
@@ -131,9 +133,11 @@ namespace REstomp.Test
         public async void StompParseHeaders()
         {
             var command = StompParser.Command.MESSAGE;
-            var headers = new Dictionary<string, string> { { "content-length", "126" } };
+            var header = new KeyValuePair<string, string>("content-length", "126");
+            var headerArray = new KeyValuePair<string, string>[1];
+            headerArray[0] = header;
 
-            var expectation = new StompFrame(command, headers);
+            var expectation = new StompFrame(command, headerArray);
 
             using (var memStream = new MemoryStream())
             using (var streamWriter = new StreamWriter(memStream))
@@ -141,9 +145,9 @@ namespace REstomp.Test
                 var eol = "\r\n";
                 streamWriter.Write(command);
                 streamWriter.Write(eol);
-                foreach (var header in headers)
+                foreach (var headerPair in headerArray)
                 {
-                    streamWriter.Write($"{header.Key}:{header.Value}");
+                    streamWriter.Write($"{headerPair.Key}:{headerPair.Value}");
                 }
                 streamWriter.Write(eol);
                 streamWriter.Write(eol);
@@ -156,7 +160,7 @@ namespace REstomp.Test
                 var parsedHeaders = await StompParser.ReadStompHeaders(parsedCommand.Item1, parsedCommand.Item2);
 
                 Assert.StrictEqual(expectation.Command, parsedCommand.Item2.Command);
-                Assert.Equal(expectation.Headers, parsedHeaders.Item2.Headers);
+                Assert.Equal(expectation.Headers[0], parsedHeaders.Item2.Headers[0]);
             }
         }
 
@@ -259,11 +263,14 @@ namespace REstomp.Test
         {
             var bodyString = "0123456789abcdefghijk1234567890abcd";
             var command = StompParser.Command.MESSAGE;
-            var headers = new Dictionary<string, string>
-                { { "content-length", bodyString.Length.ToString() } };
+
+            var header = new KeyValuePair<string, string>
+                ("content-length", bodyString.Length.ToString());
+            var headerArray = new KeyValuePair<string, string>[1];
+            headerArray[0] = header;
             var body = Encoding.UTF8.GetBytes(bodyString);
 
-            var expectation = new StompFrame(command, headers, body);
+            var expectation = new StompFrame(command, headerArray, body);
 
             using (var memStream = new MemoryStream())
             using (var streamWriter = new StreamWriter(memStream))
@@ -271,9 +278,9 @@ namespace REstomp.Test
                 var eol = "\r\n";
                 streamWriter.Write(command);
                 streamWriter.Write(eol);
-                foreach (var header in headers)
+                foreach (var headerPair in headerArray)
                 {
-                    streamWriter.Write($"{header.Key}:{header.Value}");
+                    streamWriter.Write($"{headerPair.Key}:{headerPair.Value}");
                 }
                 streamWriter.Write(eol);
                 streamWriter.Write(eol);
@@ -289,8 +296,10 @@ namespace REstomp.Test
                     .ReadStompBody(parsedHeaders.Item1, parsedHeaders.Item2, CancellationToken.None);
 
                 Assert.StrictEqual(expectation.Command, parsedCommand.Item2.Command);
-                Assert.Equal(expectation.Headers, parsedHeaders.Item2.Headers);
-                Assert.True(Encoding.UTF8.GetString(expectation.Body.ToArray())
+
+                Assert.Equal(expectation.Headers[0], parsedHeaders.Item2.Headers[0]);
+                Assert.True(Encoding.UTF8.GetString(expectation.Body.ToArray()) 
+
                     == Encoding.UTF8.GetString(parsedBody.Item2.Body.ToArray()));
                 Assert.Equal(parsedBody.Item2.Body.Length, bodyString.Length);
             }
@@ -301,11 +310,12 @@ namespace REstomp.Test
         {
             var bodyString = "0123456789abcdefghijk1234567890abcd";
             var command = StompParser.Command.MESSAGE;
-            var headers = new Dictionary<string, string>
-                    {{"key", "value"}};
+            var header = new KeyValuePair<string, string>("key", "value");
+            var headerArray = new KeyValuePair<string, string>[1];
+            headerArray[0] = header;
             var body = Encoding.UTF8.GetBytes(bodyString);
 
-            var expectation = new StompFrame(command, headers, body);
+            var expectation = new StompFrame(command, headerArray, body);
 
             using (var memStream = new MemoryStream())
             using (var streamWriter = new StreamWriter(memStream))
@@ -313,7 +323,7 @@ namespace REstomp.Test
                 var eol = "\r\n";
                 streamWriter.Write(command);
                 streamWriter.Write(eol);
-                foreach (var header in headers)
+                foreach (var headerPair in headerArray)
                 {
                     streamWriter.Write($"{header.Key}:{header.Value}");
                 }
@@ -331,7 +341,7 @@ namespace REstomp.Test
                     .ReadStompBody(parsedHeaders.Item1, parsedHeaders.Item2, CancellationToken.None);
 
                 Assert.StrictEqual(expectation.Command, parsedCommand.Item2.Command);
-                Assert.Equal(expectation.Headers, parsedHeaders.Item2.Headers);
+                Assert.Equal(expectation.Headers[0], parsedHeaders.Item2.Headers[0]);
                 Assert.True(Encoding.UTF8.GetString(expectation.Body.ToArray())
                             == Encoding.UTF8.GetString(parsedBody.Item2.Body.ToArray()));
                 Assert.Equal(parsedBody.Item2.Body.Length, bodyString.Length);
@@ -343,11 +353,12 @@ namespace REstomp.Test
         {
             var bodyString = "0123456789abcdefghijk1234567890abcd";
             var command = StompParser.Command.MESSAGE;
-            var headers = new Dictionary<string, string>
-                    {{"key", "value"}};
+            var header = new KeyValuePair<string, string>("key", "value");
+            var headerArray = new KeyValuePair<string, string>[1];
+            headerArray[0] = header;
             var body = Encoding.UTF8.GetBytes(bodyString);
 
-            var expectation = new StompFrame(command, headers, body);
+            var expectation = new StompFrame(command, headerArray, body);
 
             using (var memStream = new MemoryStream())
             using (var streamWriter = new StreamWriter(memStream))
@@ -355,9 +366,9 @@ namespace REstomp.Test
                 var eol = "\r\n";
                 streamWriter.Write(command);
                 streamWriter.Write(eol);
-                foreach (var header in headers)
+                foreach (var headerPair in headerArray)
                 {
-                    streamWriter.Write($"{header.Key}:{header.Value}");
+                    streamWriter.Write($"{headerPair.Key}:{headerPair.Value}");
                 }
                 streamWriter.Write(eol);
                 streamWriter.Write(eol);


### PR DESCRIPTION
- StrompFrame property Headers is now an ImmutableArray of KeyValue<string, string>
- Added StompHeaderExtensions to retreive keys and the value of a given key
- Updated unit tests